### PR TITLE
Add preserve underscore keys and ignore request paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,9 +122,8 @@ Alternatively, you can change this behavior on a class level by setting `json_un
         serializer_class = MySerializer
         parser_classes = (NoUnderscoreBeforeNumberCamelCaseJSONParser,)
 
-=============
-Ignore Fields
-=============
+
+** Ignore Fields **
 
 You can also specify fields which should not have their data changed.
 The specified field(s) would still have their name change, but there would be no recursion.
@@ -160,9 +159,7 @@ The `my_key` field would not have its data changed:
 
     {"myKey": {"do_not_change": 1}}
 
-===========
-Ignore Keys
-===========
+** Ignore Keys **
 
 You can also specify keys which should *not* be renamed.
 The specified field(s) would still change (even recursively).
@@ -199,6 +196,42 @@ The `unchanging_key` field would not be renamed:
     {"unchanging_key": {"changeMe": 1}}
 
 ignore_keys and ignore_fields can be applied to the same key if required.
+
+** Preserve Underscore Keys **
+
+If you need to preserve the underscore keys alongside the camel case versions for compatibility or other reasons, specify that option:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        # ...
+        "JSON_UNDERSCOREIZE": {
+            # ...
+            "preserve_underscore_keys": True,
+            # ...
+        },
+        # ...
+    }
+    
+For example:
+
+.. code-block:: python
+
+    data = {"original_key": {"another_original_key": 1}}
+
+Would become:
+
+.. code-block:: python
+
+    {
+        "originalKey": {
+            "anotherOriginalKey": 1
+        },
+        "original_key": {
+            "another_original_key": 1
+        }
+    }
+
 
 =============
 Running Tests

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,8 @@ Underscoreize Options
 =====================
 
 
-**No Underscore Before Number**
+No Underscore Before Number
+---------------------------
 
 
 As raised in `this comment <https://github.com/krasa/StringManipulation/issues/8#issuecomment-121203018>`_
@@ -123,7 +124,9 @@ Alternatively, you can change this behavior on a class level by setting `json_un
         parser_classes = (NoUnderscoreBeforeNumberCamelCaseJSONParser,)
 
 
-** Ignore Fields **
+Ignore Fields
+-------------
+
 
 You can also specify fields which should not have their data changed.
 The specified field(s) would still have their name change, but there would be no recursion.
@@ -158,8 +161,11 @@ The `my_key` field would not have its data changed:
 .. code-block:: python
 
     {"myKey": {"do_not_change": 1}}
+    
 
-** Ignore Keys **
+Ignore Keys
+-----------
+
 
 You can also specify keys which should *not* be renamed.
 The specified field(s) would still change (even recursively).
@@ -197,7 +203,10 @@ The `unchanging_key` field would not be renamed:
 
 ignore_keys and ignore_fields can be applied to the same key if required.
 
-** Preserve Underscore Keys **
+
+Preserve Underscore Keys
+------------------------
+
 
 If you need to preserve the underscore keys alongside the camel case versions for compatibility or other reasons, specify that option:
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Django REST Framework JSON CamelCase
 .. image:: https://badge.fury.io/py/djangorestframework-camel-case.svg
     :target: https://badge.fury.io/py/djangorestframework-camel-case
 
-Camel case JSON support for Django REST framework.
+Camel case JSON support for Django REST framework.  This affects input and output by default.
 
 ============
 Installation
@@ -18,7 +18,7 @@ At the command line::
 
     $ pip install djangorestframework-camel-case
 
-Add the render and parser to your django settings file.
+Add the render and parser to your django settings file as needed.  If you only want responses to be converted to camelCase, you only need the renderer classes, not the parsers (but check the settings).
 
 .. code-block:: python
 
@@ -61,8 +61,7 @@ to use another renderer, the two possible are:
 
 `drf_orjson_renderer.renderers.ORJSONRenderer` or
 `drf_ujson.renderers.UJSONRenderer` or
-`rest_framework.renderers.UnicodeJSONRenderer` for DRF < 3.0,specify it in your django
-settings file.
+`rest_framework.renderers.UnicodeJSONRenderer` for DRF < 3.0, specify it in your django
 settings file.
 
 .. code-block:: python
@@ -76,6 +75,25 @@ settings file.
 =====================
 Underscoreize Options
 =====================
+
+Normalize Inputs
+----------------
+
+By default, the middleware normalizes any incoming query parameters and other inputs from 
+camelCase to snake_case so everything passes through the same logic.  If you do not want this,
+disable the `normalize_inputs` setting:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        # ...
+        "JSON_UNDERSCOREIZE": {
+            # ...
+            "normalize_inputs": False,
+            # ...
+        },
+        # ...
+    }
 
 
 No Underscore Before Number

--- a/README.rst
+++ b/README.rst
@@ -242,6 +242,28 @@ Would become:
     }
 
 
+Ignore Request Paths
+--------------------
+
+Entire requests can be ignored by the JSON renderer.
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        # ...
+        "JSON_UNDERSCOREIZE": {
+            # ...
+            "ignore_paths": [
+                '/api/v1/my_custom_endpoint/'
+            ],
+            # ...
+        },
+        # ...
+    }
+    
+With this option set, `/api/v1/my_custom_endpoint/` would not pass through the custom renderer.
+
+
 =============
 Running Tests
 =============

--- a/djangorestframework_camel_case/middleware.py
+++ b/djangorestframework_camel_case/middleware.py
@@ -7,10 +7,11 @@ class CamelCaseMiddleWare:
         self.get_response = get_response
 
     def __call__(self, request):
-        request.GET = underscoreize(
-            request.GET,
-            **api_settings.JSON_UNDERSCOREIZE
-        )
+        if api_settings.JSON_UNDERSCOREIZE.get('normalize_inputs', False):
+            request.GET = underscoreize(
+                request.GET,
+                **api_settings.JSON_UNDERSCOREIZE
+            )
 
         response = self.get_response(request)
         return response

--- a/djangorestframework_camel_case/render.py
+++ b/djangorestframework_camel_case/render.py
@@ -8,6 +8,11 @@ class CamelCaseJSONRenderer(api_settings.RENDERER_CLASS):
     json_underscoreize = api_settings.JSON_UNDERSCOREIZE
 
     def render(self, data, *args, **kwargs):
+        # Do not camelize views handling paths that should be ignored
+        if 'view' in args[1]:
+            if args[1]['view'].request.path in self.json_underscoreize.get('ignore_paths', []):
+                return super().render(data, *args, **kwargs)
+
         return super().render(
             camelize(data, **self.json_underscoreize), *args, **kwargs
         )

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -14,6 +14,7 @@ DEFAULTS = {
         "ignore_keys": None,
         "preserve_underscore_keys": False,
         "ignore_paths": [],
+        "normalize_inputs": True
     },
 }
 

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -13,6 +13,7 @@ DEFAULTS = {
         "ignore_fields": None,
         "ignore_keys": None,
         "preserve_underscore_keys": False,
+        "ignore_paths": [],
     },
 }
 

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -8,7 +8,12 @@ USER_SETTINGS = getattr(settings, "JSON_CAMEL_CASE", {})
 DEFAULTS = {
     "RENDERER_CLASS": "rest_framework.renderers.JSONRenderer",
     "PARSER_CLASS": "rest_framework.parsers.JSONParser",
-    "JSON_UNDERSCOREIZE": {"no_underscore_before_number": False, "ignore_fields": None, "ignore_keys": None},
+    "JSON_UNDERSCOREIZE": {
+        "no_underscore_before_number": False,
+        "ignore_fields": None,
+        "ignore_keys": None,
+        "preserve_underscore_keys": False,
+    },
 }
 
 # List of settings that may be in string import notation.

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -24,6 +24,7 @@ def camelize(data, **options):
     # Handle lazy translated strings.
     ignore_fields = options.get("ignore_fields") or ()
     ignore_keys = options.get("ignore_keys") or ()
+    preserve_underscore_keys = options.get("preserve_underscore_keys", False)
     if isinstance(data, Promise):
         data = force_str(data)
     if isinstance(data, dict):
@@ -47,6 +48,8 @@ def camelize(data, **options):
                 new_dict[key] = result
             else:
                 new_dict[new_key] = result
+            if preserve_underscore_keys:
+                new_dict[key] = result
         return new_dict
     if is_iterable(data) and not isinstance(data, str):
         return [camelize(item, **options) for item in data]

--- a/tests.py
+++ b/tests.py
@@ -89,6 +89,40 @@ class UnderscoreToCamelTestCase(TestCase):
         }
         self.assertEqual(camelize(data, ignore_fields=ignore_fields, ignore_keys=ignore_keys), output)
 
+    def test_preserve_underscore_keys(self):
+        data = {
+            "two_word": 1,
+            "long_key_with_many_underscores": 2,
+            "only_1_key": 3,
+            "only_one_letter_a": 4,
+            "b_only_one_letter": 5,
+            "only_c_letter": 6,
+            "mix_123123a_and_letters": 7,
+            "mix_123123aa_and_letters_complex": 8,
+            "no_underscore_before123": 9,
+        }
+        output = {
+            "twoWord": 1,
+            "two_word": 1,
+            "longKeyWithManyUnderscores": 2,
+            "long_key_with_many_underscores": 2,
+            "only1Key": 3,
+            "only_1_key": 3,
+            "onlyOneLetterA": 4,
+            "only_one_letter_a": 4,
+            "bOnlyOneLetter": 5,
+            "b_only_one_letter": 5,
+            "onlyCLetter": 6,
+            "only_c_letter": 6,
+            "mix123123aAndLetters": 7,
+            "mix_123123a_and_letters": 7,
+            "mix123123aaAndLettersComplex": 8,
+            "mix_123123aa_and_letters_complex": 8,
+            "noUnderscoreBefore123": 9,
+            "no_underscore_before123": 9,
+        }
+        self.assertEqual(camelize(data, preserve_underscore_keys=True), output)
+
 
 class CamelToUnderscoreTestCase(TestCase):
     def test_camel_to_under_keys(self):

--- a/tests.py
+++ b/tests.py
@@ -100,8 +100,11 @@ class UnderscoreToCamelTestCase(TestCase):
             "mix_123123a_and_letters": 7,
             "mix_123123aa_and_letters_complex": 8,
             "no_underscore_before123": 9,
+            "snake_first": {"camelSecond": 1},
+            "snake_first_2": {"snake_second": 1},
+            "camelFirst": {"snake_second": 1},
         }
-        output = {
+        expected_output = {
             "twoWord": 1,
             "two_word": 1,
             "longKeyWithManyUnderscores": 2,
@@ -120,8 +123,15 @@ class UnderscoreToCamelTestCase(TestCase):
             "mix_123123aa_and_letters_complex": 8,
             "noUnderscoreBefore123": 9,
             "no_underscore_before123": 9,
+            "snakeFirst": {"camelSecond": 1},
+            "snake_first": {"camelSecond": 1},
+            "snakeFirst2": {"snakeSecond": 1, "snake_second": 1},
+            "snake_first_2": {"snakeSecond": 1, "snake_second": 1},
+            "camelFirst": {"snakeSecond": 1, "snake_second": 1},
         }
-        self.assertEqual(camelize(data, preserve_underscore_keys=True), output)
+        output = camelize(data, preserve_underscore_keys=True)
+
+        self.assertEqual(expected_output, output)
 
 
 class CamelToUnderscoreTestCase(TestCase):


### PR DESCRIPTION
This middleware has some capacity for ignoring fields and keys in returned data, but that's pretty tedious for our purposes.

This PR adds two options to the available settings:

1. `preserve_underscore_keys`, which adds the camelCase data alongside the snake_case version instead of replacing it.
2. `ignore_paths` to ignore certain request paths entirely.  We need this for the `/my_info/` endpoint.

There's a separate PR in the PPPWebPortal repo coming to use these options.