### PR TITLE
Add a custom key map setting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11","3.12"]
 
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/djangorestframework_camel_case/settings.py
+++ b/djangorestframework_camel_case/settings.py
@@ -14,7 +14,8 @@ DEFAULTS = {
         "ignore_keys": None,
         "preserve_underscore_keys": False,
         "ignore_paths": [],
-        "normalize_inputs": True
+        "normalize_inputs": True,
+        "custom_key_map": {}
     },
 }
 

--- a/djangorestframework_camel_case/util.py
+++ b/djangorestframework_camel_case/util.py
@@ -24,6 +24,7 @@ def camelize(data, **options):
     # Handle lazy translated strings.
     ignore_fields = options.get("ignore_fields") or ()
     ignore_keys = options.get("ignore_keys") or ()
+    custom_key_map = options.get("custom_key_map") or {}
     preserve_underscore_keys = options.get("preserve_underscore_keys", False)
     if isinstance(data, Promise):
         data = force_str(data)
@@ -36,7 +37,10 @@ def camelize(data, **options):
             if isinstance(key, Promise):
                 key = force_str(key)
             if isinstance(key, str) and "_" in key:
-                new_key = re.sub(camelize_re, underscore_to_camel, key)
+                if key in custom_key_map:
+                    new_key = custom_key_map[key]
+                else:
+                    new_key = re.sub(camelize_re, underscore_to_camel, key)
             else:
                 new_key = key
 

--- a/tests.py
+++ b/tests.py
@@ -133,6 +133,46 @@ class UnderscoreToCamelTestCase(TestCase):
 
         self.assertEqual(expected_output, output)
 
+    def test_custom_key_map(self):
+        data = {
+            "two_word": 1,
+            "long_key_with_many_underscores": 2,
+            "only_1_key": 3,
+            "only_one_letter_a": 4,
+            "b_only_one_letter": 5,
+            "only_c_letter": 6,
+            "mix_123123a_and_letters": 7,
+            "mix_123123aa_and_letters_complex": 8,
+            "no_underscore_before123": 9,
+            "snake_first": {"camelSecond": 1},
+            "snake_first_2": {"snake_second": 1},
+            "camelFirst": {"snake_second": 1},
+            "push_to_qa": True,
+            "my_other_custom_key": True
+        }
+        expected_output = {
+            "twoWord": 1,
+            "longKeyWithManyUnderscores": 2,
+            "only1Key": 3,
+            "onlyOneLetterA": 4,
+            "bOnlyOneLetter": 5,
+            "onlyCLetter": 6,
+            "mix123123aAndLetters": 7,
+            "mix123123aaAndLettersComplex": 8,
+            "noUnderscoreBefore123": 9,
+            "snakeFirst": {"camelSecond": 1},
+            "snakeFirst2": {"snakeSecond": 1},
+            "camelFirst": {"snakeSecond": 1},
+            "pushToQA": True,
+            "myOther_CustomKey": True
+        }
+        output = camelize(data, custom_key_map={
+            'push_to_qa': 'pushToQA',
+            'my_other_custom_key': 'myOther_CustomKey'
+        })
+
+        self.assertEqual(expected_output, output)
+
 
 class CamelToUnderscoreTestCase(TestCase):
     def test_camel_to_under_keys(self):


### PR DESCRIPTION
This adds a `custom_key_map` setting so specific underscore->snakeCase transforms can be customized.

Specifically we're going to need this for `canQA` rather than `canQa`.  The settings would look as follows:

```python
    'JSON_UNDERSCOREIZE': {
        'normalize_inputs': True,
        'preserve_underscore_keys': False,
        'ignore_keys': ['my_info', 'response-content-disposition'],
        'ignore_fields': ['my_info', 'Content-Disposition'],
        'ignore_paths': [
            '/api/v1/my_info/',
            '/rest-auth/login/',
        ],
        'custom_key_map': {
            'can_qa': 'canQA'
        }
    }
```